### PR TITLE
Create initial code of conduct based on The Contributor Covenant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+themes/*
+themes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 To test things locally, run the following after cloning:
 ```
+$ git submodule add https://github.com/budparr/gohugo-theme-ananke.git themes/ananke
+```
+
+To optionally add more themes:
+```
 $ git clone --recursive https://github.com/gohugoio/hugoThemes themes/
 ```
 

--- a/content/about.md
+++ b/content/about.md
@@ -85,7 +85,7 @@ If you are offended by the fact we renamed the project, we suggest you continue 
 
 
 ## Where is the Glimpse code of conduct? {#where-is-the-glimpse-code-of-conduct}
-There isn't one yet as it is still being discussed by the community, but it is likely to be based on [the contributor covenant](https://www.contributor-covenant.org/) or something similar. As this project spawned from [the fediverse](https://joinmastodon.org/) our experiences in that online space are going to inform the project's future governance and direction.
+You will find it on [this page](../code-of-conduct/). It is based on [the contributor covenant](https://www.contributor-covenant.org/) and will be developed and amended over time as the need arises. As this project spawned from [the fediverse](https://joinmastodon.org/) our experiences in that online space are going to inform the project's future governance and direction.
 
 There is no [benevolent dictator for life](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) for this fork because we value collective decision-making. We believe a governing group is less fallible, makes better-considered choices and reflects the will of the wider community more accurately. That approach will help us form a robust and fair code of conduct, and we have elaborated more on our current governance structure here: ["Why is there is no lead developer on this project?"](#why-is-there-no-lead-developer-on-this-project)
 

--- a/content/about.md
+++ b/content/about.md
@@ -85,7 +85,7 @@ If you are offended by the fact we renamed the project, we suggest you continue 
 
 
 ## Where is the Glimpse code of conduct? {#where-is-the-glimpse-code-of-conduct}
-You will find it on [this page](../code-of-conduct/). It is based on [the contributor covenant](https://www.contributor-covenant.org/) and will be developed and amended over time as the need arises. As this project spawned from [the fediverse](https://joinmastodon.org/) our experiences in that online space are going to inform the project's future governance and direction.
+You will find it on [this page](../code-of-conduct/). Our code of conduct is based on [the contributor covenant](https://www.contributor-covenant.org/) and will be developed and amended over time as the need arises. As this project spawned from [the fediverse](https://joinmastodon.org/) our experiences in that online space are going to inform the project's future governance and direction.
 
 There is no [benevolent dictator for life](https://en.wikipedia.org/wiki/Benevolent_dictator_for_life) for this fork because we value collective decision-making. We believe a governing group is less fallible, makes better-considered choices and reflects the will of the wider community more accurately. That approach will help us form a robust and fair code of conduct, and we have elaborated more on our current governance structure here: ["Why is there is no lead developer on this project?"](#why-is-there-no-lead-developer-on-this-project)
 

--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -4,8 +4,6 @@ date: 2019-07-13T16:19:01+01:00
 draft: false
 menu: "main"
 ---
-# Glimpse Project Code of Conduct
-
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as

--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -2,6 +2,7 @@
 title: "Code of Conduct"
 date: 2019-07-13T16:19:01+01:00
 draft: false
+menu: "main"
 ---
 # Glimpse Project Code of Conduct
 

--- a/content/code-of-conduct.md
+++ b/content/code-of-conduct.md
@@ -1,0 +1,83 @@
+---
+title: "Code of Conduct"
+date: 2019-07-13T16:19:01+01:00
+draft: false
+---
+# Glimpse Project Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting any member of the project leadership (sometimes called
+"the governing team") on Matrix: [TrechNex](https://matrix.to/#/@treacherousnexus:matrix.org), [BrainBlasted](https://matrix.to/#/@brainblasted:disroot.org), [Clipsey](https://matrix.to/#/@clipsey:matrix.org).
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project leadership
+is obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
The main change is directing users to report problems to one of the three admin types via Matrix.