### PR TITLE
Fixed warning and removed link

### DIFF
--- a/content/contribute.md
+++ b/content/contribute.md
@@ -29,7 +29,4 @@ menu: "main"
 
 ## Community Supported Channels
 We welcome members of our community starting their own unofficial support forums and communication channels.
-Please note that we do not monitor or moderate these links, and cannot guarantee they are a safe and welcoming environment for everyone.
-**If you choose to use these communication channels, you do so at your own risk.**
-
-* [Reddit](https://www.reddit.com/r/GlimpseEditor/)
+Please note that we do not monitor or moderate those platforms, and cannot guarantee they are a safe and welcoming environment for everyone. **If you choose to use them, you do so at your own risk.**


### PR DESCRIPTION
This was requested within the project, so updates the warning at the bottom of contribute page and enacts the policy that we do not link to community communication channels that we do not monitor or actively support.